### PR TITLE
Fix dupe option appearing when view/take

### DIFF
--- a/assets/scripts/templates/survey-update-form.handlebars
+++ b/assets/scripts/templates/survey-update-form.handlebars
@@ -8,16 +8,11 @@
     <input name='survey[description]' class="form-control" type='text' placeholder="description" value="{{survey.description}}">
     <br>
     <label>Answer Options:</label>
-    {{#each survey.optionsWithIndex as |optionObject|}}
-      <input name='options[{{optionObject.optionArrayIndex}}]'
-         class="form-control" type='text'
-         placeholder="Option {{optionObject.optionArrayIndex}}"
-         value="{{optionObject.option}}">
-    {{/each}}
-    <!-- <input name='options[1]' class="form-control" type='text' placeholder="Option 2" value="{{survey.options.[1].option}}" required>
+    <input name='options[0]' class="form-control" type='text' placeholder="Option 1" value="{{survey.options.[0].option}}" required>
+    <input name='options[1]' class="form-control" type='text' placeholder="Option 2" value="{{survey.options.[1].option}}" required>
     <input name='options[2]' class="form-control" type='text' placeholder="Option 3" value="{{survey.options.[2].option}}" required>
     <input name='options[3]' class="form-control" type='text' placeholder="Option 4" value="{{survey.options.[3].option}}" required>
-    <input name='options[4]' class="form-control" type='text' placeholder="Option 5" value="{{survey.options.[4].option}}" required> -->
+    <input name='options[4]' class="form-control" type='text' placeholder="Option 5" value="{{survey.options.[4].option}}" required>
     <br>
     <input type='submit' class="form-control" value='Submit Survey'>
   </fieldset>

--- a/assets/scripts/templates/survey-view-and-take.handlebars
+++ b/assets/scripts/templates/survey-view-and-take.handlebars
@@ -1,11 +1,6 @@
 <div class="view-or-take-survey box">
   <h2>{{survey.name}}</h2>
   <h4>{{survey.description}}</h4>
-  <div class='box'>
-    <p name='options[0]'>{{survey.options.[0].option}}</p>
-    <p>Number of Votes: {{survey.options.[0].numVotes}}</p>
-    <button data-vote-id="0" class="vote-button">Vote</button>
-  </div>
   {{#each survey.optionsWithIndex as |optionObject|}}
     <div class='box'>
       <p name='options[{{optionObject.optionArrayIndex}}]'>{{optionObject.option}}</p>


### PR DESCRIPTION
The previous commit for allowing less than five introduced a regression:
when you clicked view/take, the first option appeared twice.

This happened when switching from 5 hardcoded option array to a
handlebar loop.  The first hardcoded option was not removed.