### PR TITLE
Support < 5 or > 5 options

### DIFF
--- a/assets/scripts/surveys/ui.js
+++ b/assets/scripts/surveys/ui.js
@@ -7,6 +7,27 @@ const indexMySurveysTemplate = require('../templates/survey-index-my-surveys.han
 const updateSurveyForm = require('../templates/survey-update-form.handlebars')
 const viewTakeSurvey = require('../templates/survey-view-and-take.handlebars')
 
+// TODO: Refactor to include index attribute in data model
+// TODO: Figure out javascript syntax for documenting functions
+// TODO: Modify for an "ADD" button which will add 5 to the rows
+// Copies survey.options to survey.optionsWithIndex and adds index attribute
+// to keep track of the row to make it easy for handlebars.
+// Adds x number of blank rows to optionsWithIndex
+function _addOptionsWithIndex (survey, addBlankRows) {
+  const optionsWithIndex = survey.options.slice(0)
+  const rowsToDisplay = optionsWithIndex.length + addBlankRows
+  for (let i = 0; i < optionsWithIndex.length; i++) {
+    optionsWithIndex[i].optionArrayIndex = i
+  }
+  for (let j = optionsWithIndex.length; j < rowsToDisplay; j++) {
+    optionsWithIndex[j] = {
+      option: '',
+      optionArrayIndex: j
+    }
+  }
+  survey.optionsWithIndex = optionsWithIndex
+}
+
 // index all surveys (created by any user)
 const onIndexAllSurveysSuccess = function (response) {
   store.surveys = response.surveys
@@ -69,8 +90,10 @@ const onIndexMySurveysSuccess = function (response) {
 
 // show a single survey that a user wants to edit/update
 const onShowSurveySuccess = function (response) {
+  const survey = response.survey
+  _addOptionsWithIndex(survey, 5)
   const surveyFormHtml = updateSurveyForm({
-    survey: response.survey
+    survey: survey
   })
   $('.survey-content').html(surveyFormHtml)
   $('.message').text(`Edit your survey! Note: we ensured vote count remains if you update the text field for an option.`)
@@ -82,6 +105,7 @@ const onShowSurveySuccess = function (response) {
 // show a single survey with options to vote!
 const onViewTakeSurveySuccess = function (response) {
   store.survey = response.survey
+  _addOptionsWithIndex(response.survey, 0)
   const surveyHtml = viewTakeSurvey({
     survey: response.survey
   })

--- a/assets/scripts/templates/survey-index-all-surveys.handlebars
+++ b/assets/scripts/templates/survey-index-all-surveys.handlebars
@@ -8,9 +8,10 @@
       {{survey.description}}
       {{/if}}
     </h4>
-    <p>Options: {{survey.options.[0].option}}, {{survey.options.[1].option}},
-      {{survey.options.[2].option}}, {{survey.options.[3].option}},
-      {{survey.options.[4].option}}
+    <p>Options:
+      {{#each survey.options as |fetchedOption|}}
+        {{fetchedOption.option}}:
+      {{/each}}
     </p>
     <button class='btn btn-sm btn-dark view-take-survey-button' data-id="{{_id}}">View/Take</button>
   </div>

--- a/assets/scripts/templates/survey-index-my-surveys.handlebars
+++ b/assets/scripts/templates/survey-index-my-surveys.handlebars
@@ -9,9 +9,10 @@
       {{/if}}
     </h4>
     <div class='options'>
-      <p>Options: {{survey.options.[0].option}}, {{survey.options.[1].option}},
-        {{survey.options.[2].option}}, {{survey.options.[3].option}},
-        {{survey.options.[4].option}}
+      <p>Options:
+      {{#each survey.options as |fetchedOption|}}
+        {{fetchedOption.option}}:
+      {{/each}}
       </p>
       {{> survey-delete-button }}
       {{> survey-update-button }}

--- a/assets/scripts/templates/survey-update-form.handlebars
+++ b/assets/scripts/templates/survey-update-form.handlebars
@@ -8,11 +8,12 @@
     <input name='survey[description]' class="form-control" type='text' placeholder="description" value="{{survey.description}}">
     <br>
     <label>Answer Options:</label>
-    <input name='options[0]' class="form-control" type='text' placeholder="Option 2" value="{{survey.options.[0].option}}" required>
-    <input name='options[1]' class="form-control" type='text' placeholder="Option 2" value="{{survey.options.[1].option}}" required>
-    <input name='options[2]' class="form-control" type='text' placeholder="Option 3" value="{{survey.options.[2].option}}" required>
-    <input name='options[3]' class="form-control" type='text' placeholder="Option 4" value="{{survey.options.[3].option}}" required>
-    <input name='options[4]' class="form-control" type='text' placeholder="Option 5" value="{{survey.options.[4].option}}" required>
+    {{#each survey.optionsWithIndex as |optionObject|}}
+      <input name='options[{{optionObject.optionArrayIndex}}]'
+         class="form-control" type='text'
+         placeholder="Option {{optionObject.optionArrayIndex}}"
+         value="{{optionObject.option}}">
+    {{/each}}
     <br>
     <input type='submit' class="form-control" value='Submit Survey'>
   </fieldset>

--- a/assets/scripts/templates/survey-view-and-take.handlebars
+++ b/assets/scripts/templates/survey-view-and-take.handlebars
@@ -1,29 +1,13 @@
 <div class="view-or-take-survey box">
   <h2>{{survey.name}}</h2>
   <h4>{{survey.description}}</h4>
-  <div class='box'>
-    <p name='options[0]'>{{survey.options.[0].option}}</p>
-    <p>Number of Votes: {{survey.options.[0].numVotes}}</p>
-    <button data-vote-id="0" class="vote-button btn btn-light btn-sm">Vote</button>
-  </div>
-  <div class='box'>
-    <p name='options[1]'>{{survey.options.[1].option}}</p>
-    <p>Number of Votes: {{survey.options.[1].numVotes}}</p>
-    <button data-vote-id="1" class="vote-button btn btn-light btn-sm">Vote</button>
-  </div>
-  <div class='box'>
-    <p name='options[2]'>{{survey.options.[2].option}}</p>
-    <p>Number of Votes: {{survey.options.[2].numVotes}}</p>
-    <button data-vote-id="2" class="vote-button btn btn-light btn-sm">Vote</button>
-  </div>
-  <div class='box'>
-    <p name='options[3]'>{{survey.options.[3].option}}</p>
-    <p>Number of Votes: {{survey.options.[3].numVotes}}</p>
-    <button data-vote-id="3" class="vote-button btn btn-light btn-sm">Vote</button>
-  </div>
-  <div class='box'>
-    <p name='options[4]'>{{survey.options.[4].option}}</p>
-    <p>Number of Votes: {{survey.options.[4].numVotes}}</p>
-    <button data-vote-id="4" class="vote-button btn btn-light btn-sm">Vote</button>
-  </div>
+  {{#each survey.optionsWithIndex as |optionObject|}}
+    <div class='box'>
+      <p name='options[{{optionObject.optionArrayIndex}}]'>{{optionObject.option}}</p>
+      <p>Number of Votes: {{optionObject.numVotes}}</p>
+      <button data-vote-id="{{optionObject.optionArrayIndex}}"
+         class="vote-button btn btn-light btn-sm">Vote</button>
+    </div>
+  {{/each}}
+  <button class="back-button-survey" class="btn btn-sm">Back</button>
 </div>


### PR DESCRIPTION
When you click Edit, five blank rows will be added on the screen.
On save, any blank rows are removed in the backend code.

When you Submit after editing, numVotes will stay the same
based on option string value.  If you rename an option, count is lost.
If you change a string value and then enter the same string value in a
different row, the numVotes is preserved.

Note if there are duplicates, numVotes is only saved for the first one,
but it is a bug that you can have duplicate option strings